### PR TITLE
Fix pyproject.toml metadata for xai-pycaret

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "xai-pycaret"
 version = "0.1.0"
-description = "Xircuits component library for PyTorch."
+description = "Xircuits component library for PyCaret."
 authors = [{ name = "XpressAI", email = "eduardo@xpress.ai" }]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/XpressAI/xai-pycaret"
-keywords = ["xircuits", "pytorch", "data preprocessing", "classification"]
+keywords = ["xircuits", "pycaret", "data preprocessing", "classification"]
 
 dependencies = [
     "Cython",


### PR DESCRIPTION
# Description

This PR fixes metadata issues in the `pyproject.toml` of **xai-pycaret**:
- Corrected `description` to mention PyCaret instead of PyTorch.
- Cleaned up keywords to match the library's purpose.
- Ensured `README.md` is properly referenced.
- Verified `default_example_path` points to a valid example